### PR TITLE
Replaced concatenated strings with template literals in the test/index.js

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -164,7 +164,7 @@ describe('split_hostname', function () {
     assert.equal(foo[1],'domain.com');
   });
   [1,2,3].forEach(function (level) {
-    it('splits on domain boundary, level ' + level, function () {
+    it(`splits on domain boundary, level ${level}`, function () {
       const foo = tlds.split_hostname('host.sub1.sub2.domain.com', level);
       assert.equal(foo[0],'host.sub1.sub2');
       assert.equal(foo[1],'domain.com');


### PR DESCRIPTION
updates: https://github.com/haraka/Haraka/issues/2129