### PR TITLE
Add logger which can be disabled via process.env

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ const regex = {
   line:           /^\s*(.*?)\s*$/,
 }
 
+const logger = {
+  log: (message) => {
+    if (process.env.HARAKA_TLD_LOG_LOADING === undefined || process.env.HARAKA_TLD_LOG_LOADING !== 'false')
+      console.log(message);
+  },
+}
+
 module.exports = exports = {
   public_suffix_list: {},
   top_level_tlds: {},
@@ -147,7 +154,7 @@ function load_public_suffix_list () {
     exports.public_suffix_list[suffix] = [];
   })
 
-  console.log(`loaded ${Object.keys(exports.public_suffix_list).length} Public Suffixes`);
+  logger.log(`loaded ${Object.keys(exports.public_suffix_list).length} Public Suffixes`);
 }
 
 function load_tld_files () {
@@ -173,7 +180,7 @@ function load_tld_files () {
     }
   })
 
-  console.log(`loaded TLD files:
+  logger.log(`loaded TLD files:
   1=${Object.keys(exports.top_level_tlds).length}
   2=${Object.keys(exports.two_level_tlds).length}
   3=${Object.keys(exports.three_level_tlds).length}`

--- a/index.js
+++ b/index.js
@@ -18,10 +18,15 @@ const regex = {
 
 const logger = {
   log: (message) => {
-    if (process.env.HARAKA_TLD_LOG_LOADING === undefined || process.env.HARAKA_TLD_LOG_LOADING !== 'false')
-      console.log(message);
+    switch (process.env.HARAKA_LOGS_SUPPRESS) {
+      case undefined:
+      case "false":
+      case "0":
+        console.log(message);
+    }
   },
-}
+};
+
 
 module.exports = exports = {
   public_suffix_list: {},


### PR DESCRIPTION
Hello!

I am using your library and found it very useful for grouping addresses by their organizational domain, so thanks for your work!

But I found the logging of the TLD files loading during startup slightly annoying so I looked for a way to disable it. I have come across #29 and there you mentioned you would welcome a patch so here I am :)

Example usage:

```sh
$ node index.js 
loaded TLD files:
  1=1504
  2=8569
  3=2448
loaded 9105 Public Suffixes
$ HARAKA_TLD_LOG_LOADING=false node index.js
$
```

This should not break anything which may depend (for whatever horrifying reason :D) that the loading is logged on startup since by default, it does still log the output. It just can be disabled by assigning *exactly* 'false'  to HARAKA_TLD_LOG_LOADING

This means in the following, the loading is still logged:
```
$ HARAKA_TLD_LOG_LOADING=0 node index.js 
loaded TLD files:
  1=1504
  2=8569
  3=2448
loaded 9105 Public Suffixes
$ HARAKA_TLD_LOG_LOADING=1 node index.js 
loaded TLD files:
  1=1504
  2=8569
  3=2448
loaded 9105 Public Suffixes
```

I could have used some additional conditions like `=== '0'` etc but I wanted to keep as simple as possible and first hear what you think about it :)

Would be glad to hear from you!